### PR TITLE
Improve main documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,10 +24,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install nightly Rust
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Rustdoc
-        run: cargo doc --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: --crate-version main
+        run:
+          cargo doc --no-deps --document-private-items -Z rustdoc-map -Z rustdoc-scrape-examples=examples
       - name: Setup Pages
         uses: actions/configure-pages@v1
       - name: Upload artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,5 @@ path = "tests/util.rs"
 test = false
 
 [package.metadata.docs.rs]
+cargo-args = ["-Zrustdoc-scrape-examples=examples"]
 targets = []

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io Version](https://img.shields.io/crates/v/axum-server-dual-protocol.svg)](https://crates.io/crates/axum-server-dual-protocol)
 [![Live Build Status](https://img.shields.io/github/checks-status/daxpedda/axum-server-dual-protocol/main?label=CI)](https://github.com/daxpedda/axum-server-dual-protocol/actions?query=branch%3Amain)
 [![Docs.rs Documentation](https://img.shields.io/docsrs/axum-server-dual-protocol)](https://docs.rs/crate/axum-server-dual-protocol)
-[![Master Documentation](https://img.shields.io/github/workflow/status/daxpedda/axum-server-dual-protocol/Documentation?label=master%20docs)](https://daxpedda.github.io/axum-server-dual-protocol/axum_server_dual_protocol/index.html)
+[![Main Documentation](https://img.shields.io/github/workflow/status/daxpedda/axum-server-dual-protocol/Documentation?label=main%20docs)](https://daxpedda.github.io/axum-server-dual-protocol/axum_server_dual_protocol/index.html)
 
 ## Description
 


### PR DESCRIPTION
- Replace version number with "main" in the generated documentation.
- Use `-Z rustdoc-map` to automatically link all types in dependencies to their appropriate location in docs.rs.
- Add scraping examples to the main documentation and docs.rs.
- Correct badge label in README from "master docs" to "main docs".