### PR TITLE
Minor improvements

### DIFF
--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,4 +1,5 @@
-7
+8
+backported
 Changelog
 HTTPS
 MSRV

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 
 Provides utilities to host a [`axum-server`] server that
 accepts the HTTP and HTTPS protocol on the same port. See
-[`bind_dual_protocol`].
+[`bind_dual_protocol()`].
 
 A common use case for this is if a HTTPS server is hosted on a
 non-traditional port, having no corresponding HTTP port. This can be an
 issue for clients who try to connect over HTTP and get a connection reset
-error.
+error. See [`ServerExt::set_upgrade()`].
 
 ## Usage
 
-The simplest way to start is to use [`bind_dual_protocol`]:
+The simplest way to start is to use [`bind_dual_protocol()`]:
 ```rust
 let app = Router::new().route("/", routing::get(|| async { "Hello, world!" }));
 
@@ -80,7 +80,7 @@ conditions.
 [LICENSE-APACHE]: https://github.com/daxpedda/axum-server-dual-protocol/blob/main/LICENSE-APACHE
 [`axum`]: https://docs.rs/axum/0.5
 [`axum-server`]: https://docs.rs/axum-server/~0.4.1
-[`bind_dual_protocol`]: https://docs.rs/axum-server-dual-protocol/0.1
+[`bind_dual_protocol()`]: https://docs.rs/axum-server-dual-protocol/0.1/axum_server_dual_protocol/fn.bind_dual_protocol.html
 [`hyper`]: https://docs.rs/hyper/0.14
 [`Layer`]: https://docs.rs/tower-layer/0.3/tower_layer/trait.Layer.html
 [`Router`]: https://docs.rs/axum/0.5/axum/struct.Router.html

--- a/src/dual_protocol.rs
+++ b/src/dual_protocol.rs
@@ -1,6 +1,6 @@
 //! Dual-protocol server implementation.
 //!
-//! See [`bind_dual_protocol`] and [`DualProtocolAcceptor`].
+//! See [`bind_dual_protocol()`] and [`DualProtocolAcceptor`].
 
 use std::fmt::{self, Debug, Formatter};
 use std::future::Future;

--- a/src/either.rs
+++ b/src/either.rs
@@ -1,3 +1,9 @@
+//! This is a copy of
+//! <https://github.com/hyperium/http-body/blob/6d7dd177dcbea2ffd1067f9f344beda7af5c78f2/http-body-util/src/either.rs>
+//! and will be unnecessary if the crate is released and dependencies update or
+//! `Either` is backported to `http-body` 0.4. See
+//! <https://github.com/hyperium/http-body/issues/66>.
+
 #![allow(unsafe_code, warnings)]
 
 use std::error::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,19 +2,20 @@
 //!
 //! Provides utilities to host a [`axum-server`](axum_server) server that
 //! accepts the HTTP and HTTPS protocol on the same port. See
-//! [`bind_dual_protocol`].
+//! [`bind_dual_protocol()`].
 //!
 //! A common use case for this is if a HTTPS server is hosted on a
 //! non-traditional port, having no corresponding HTTP port. This can be an
 //! issue for clients who try to connect over HTTP and get a connection reset
-//! error.
+//! error. See [`ServerExt::set_upgrade()`].
 //!
 //! # Usage
 //!
-//! The simplest way to start is to use [`bind_dual_protocol`]:
+//! The simplest way to start is to use [`bind_dual_protocol()`]:
 //! ```no_run
 //! # use axum::{routing, Router};
 //! # use axum_server::tls_rustls::RustlsConfig;
+//! #
 //! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
 //! let app = Router::new().route("/", routing::get(|| async { "Hello, world!" }));
@@ -23,6 +24,7 @@
 //! # let certificate = rcgen::generate_simple_self_signed([])?;
 //! # let private_key = certificate.serialize_private_key_der();
 //! # let certificate = vec![certificate.serialize_der()?];
+//! #
 //! // User-supplied certificate and private key.
 //! let config = RustlsConfig::from_der(certificate, private_key).await?;
 //!

--- a/src/upgrade_http.rs
+++ b/src/upgrade_http.rs
@@ -17,8 +17,9 @@ use tower_layer::Layer;
 
 use crate::Either;
 
-/// [`Layer`] upgrading HTTP requests to HTTPS. See [`UpgradeHttp`] for more
-/// details.
+/// [`Layer`] upgrading HTTP requests to HTTPS.
+///
+/// See [`UpgradeHttp`] for more details.
 #[derive(Clone, Copy, Debug)]
 pub struct UpgradeHttpLayer;
 
@@ -122,21 +123,7 @@ pub struct UpgradeHttpFuture<Service, Request>(#[pin] FutureServe<Service, Reque
 where
 	Service: HyperService<Request>;
 
-// Rust can't figure out the correct bounds.
-impl<Service, Request> Debug for UpgradeHttpFuture<Service, Request>
-where
-	Service: HyperService<Request>,
-	FutureServe<Service, Request>: Debug,
-{
-	fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
-		formatter
-			.debug_tuple("UpgradeHttpFuture")
-			.field(&self.0)
-			.finish()
-	}
-}
-
-/// [`Future`] holding what to serve for [`UpgradeHttpFuture`].
+/// Holds [`Future`] to serve for [`UpgradeHttpFuture`].
 #[derive(Debug)]
 #[pin_project(project = UpgradeHttpFutureProj)]
 enum FutureServe<Service, Request>
@@ -149,6 +136,20 @@ where
 	/// The request was using the HTTP protocol, so we
 	/// will upgrade the connection.
 	Upgrade(Option<Response<Body>>),
+}
+
+// Rust can't figure out the correct bounds.
+impl<Service, Request> Debug for UpgradeHttpFuture<Service, Request>
+where
+	Service: HyperService<Request>,
+	FutureServe<Service, Request>: Debug,
+{
+	fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+		formatter
+			.debug_tuple("UpgradeHttpFuture")
+			.field(&self.0)
+			.finish()
+	}
 }
 
 // TODO: This was stabilized in 1.61, our MSRV is 1.56 currently because of


### PR DESCRIPTION
- Add parentheses to functions in documentation to make it easy to identify.
- Fix link to `bind_dual_protocol()` in README.
- Make code examples more readable by adding more newlines.
- Add documentation to the `either` module.
- Minimally improve documentation of `UpgradeHttpLayer` and `FutureServe`.
- Move trait implementations after type definitions in `upgrade_http`.