### PR TITLE
`Protocol` extension

### DIFF
--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,4 +1,4 @@
-10
+11
 backported
 Changelog
 HTTPS
@@ -9,3 +9,4 @@ URI
 v0
 v1
 Versioning
+WebSocket

--- a/.config/topic.dic
+++ b/.config/topic.dic
@@ -1,10 +1,11 @@
-11
+12
 backported
 Changelog
 HTTPS
 MSRV
 TLS
 TODO
+unencrypted
 URI
 v0
 v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal --component clippy
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Clippy

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Run Spellcheck
-        run: cargo spellcheck check -m 1 CHANGELOG.md
+        run: |
+          cargo spellcheck check -m 1
+          cargo spellcheck check -m 1 CHANGELOG.md
 
   typos:
     name: Typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Introduced [`Protocol`](https://daxpedda.github.io/axum-server-dual-protocol/axum_server_dual_protocol/struct.Protocol.html).
+  Which can be used with [`Request::extensions()`](https://docs.rs/http/0.2.9/http/request/struct.Request.html#method.extensions)
+  to extract this connections protocol.
+
+### Fixed
+- Secure WebSocket handshakes are now accepted, instead of redirected to the `https` URI scheme.
+
 ## [0.4.0] - 2023-05-04
 ### Changed
 - Updated `axum-server` to v0.5.
@@ -30,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial commit.
 
+[Unreleased]: https://github.com/daxpedda/axum-server-dual-protocol/compare/v0.4.0...main
 [0.4.0]: https://github.com/daxpedda/axum-server-dual-protocol/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/daxpedda/axum-server-dual-protocol/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/daxpedda/axum-server-dual-protocol/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Secure WebSocket handshakes are now accepted, instead of redirected to the `https` URI scheme.
 - Upgrade insecure WebSocket handshakes to the `wss` instead of the `https` URI scheme.
 
+### Changed
+- Unknown URI schemes are now responded to with "400 Bad Request" instead of redirected to the `https` URI scheme.
+
 ## [0.4.0] - 2023-05-04
 ### Changed
 - Updated `axum-server` to v0.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Secure WebSocket handshakes are now accepted, instead of redirected to the `https` URI scheme.
+- Upgrade insecure WebSocket handshakes to the `wss` instead of the `https` URI scheme.
 
 ## [0.4.0] - 2023-05-04
 ### Changed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ error. See [`ServerExt::set_upgrade()`].
 
 The simplest way to start is to use [`bind_dual_protocol()`]:
 ```rust
-let app = Router::new().route("/", routing::get(|| async { "Hello, world!" }));
+let app = Router::new().route(
+	"/",
+	routing::get(|request: Request<Body>| async move {
+		match request.extensions().get::<Protocol>().unwrap() {
+			Protocol::Tls => "Hello, secure World!",
+			Protocol::Plain => "Hello, insecure World!",
+		}
+	}),
+);
 
 // User-supplied certificate and private key.
 let config = RustlsConfig::from_der(certificate, private_key).await?;

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,1 @@
 allow-unwrap-in-tests = true
-msrv = "1.60.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,21 @@
 //! ```no_run
 //! # use axum::{routing, Router};
 //! # use axum_server::tls_rustls::RustlsConfig;
+//! # use axum_server_dual_protocol::Protocol;
+//! # use http::Request;
+//! # use hyper::Body;
 //! #
 //! # #[tokio::main]
 //! # async fn main() -> anyhow::Result<()> {
-//! let app = Router::new().route("/", routing::get(|| async { "Hello, world!" }));
+//! let app = Router::new().route(
+//! 	"/",
+//! 	routing::get(|request: Request<Body>| async move {
+//! 		match request.extensions().get::<Protocol>().unwrap() {
+//! 			Protocol::Tls => "Hello, secure World!",
+//! 			Protocol::Plain => "Hello, insecure World!",
+//! 		}
+//! 	}),
+//! );
 //!
 //! # let address = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
 //! # let certificate = rcgen::generate_simple_self_signed([])?;
@@ -113,7 +124,7 @@ mod upgrade_http;
 
 pub use dual_protocol::{
 	bind_dual_protocol, from_tcp_dual_protocol, DualProtocolAcceptor, DualProtocolAcceptorFuture,
-	DualProtocolService, DualProtocolServiceFuture, ServerExt,
+	DualProtocolService, DualProtocolServiceFuture, Protocol, ServerExt,
 };
 pub use either::Either;
 pub use upgrade_http::{UpgradeHttp, UpgradeHttpFuture, UpgradeHttpLayer};

--- a/src/upgrade_http.rs
+++ b/src/upgrade_http.rs
@@ -92,7 +92,7 @@ where
 				let response = Response::builder();
 
 				let response = if let Some(authority) = extract_authority(&request) {
-					// Build URI to redirect too.
+					// Build URI to redirect to.
 					let mut uri = Uri::builder().scheme(Scheme::HTTPS).authority(authority);
 
 					if let Some(path_and_query) = request.uri().path_and_query() {


### PR DESCRIPTION
This introduces a new [extension](https://docs.rs/http/0.2.9/http/request/struct.Request.html#method.extensions): `Protocol`; which can help users determine if the connection is using TLS or not. I also adjusted the examples to show how to use it.

The `UpgradeHttp` service now uses `Protocol` to determine if the connection is using TLS or not, instead of the unreliable URI scheme.

In addition insecure WebSocket handshakes are now redirected to the `wss` instead of the `https` URI scheme.
Unfortunately WebSocket handshake redirects are not supports by browsers, see [the WHATWG spec](https://websockets.spec.whatwg.org/#websocket-opening-handshake).

Additionally, unknown URI schemes are detected and responded to with "400 Bad Request".

Replaces https://github.com/daxpedda/axum-server-dual-protocol/pull/19.
Cc @tirithen.