### PR TITLE
feat: bump axum_server to 0.8.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - { description: MSRV, version: 1.66, msrv: true }
+          - { description: MSRV, version: 1.82, msrv: true }
           - { description: Stable, version: stable, msrv: false }
         features:
           - { description: "", features: "" }
@@ -37,7 +37,7 @@ jobs:
           rustup default ${{ matrix.rust.version }}
       - name: Fix MSRV dependencies
         if: matrix.rust.msrv == true
-        run: cargo update -p tokio --precise 1.38.1
+        run: cargo update -p tokio --precise 1.41.1
       - name: Build
         run: cargo build ${{ matrix.features.features }}
       - name: Documentation
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - { description: MSRV, version: 1.66 }
+          - { description: MSRV, version: 1.82 }
           - { description: Stable, version: stable }
         features:
           - { description: "", features: "" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0]
+
+### Changed
+
+- Increased MSRV to v1.82.
+- Updated `axum-server` to v0.8.
+- Updated `from_tcp_dual_protocol` return an `io::Result<Server<SocketAddr, DualProtocolAcceptor>>`
+
 ## [0.7.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["axum-server", "server", "web", "http", "https"]
 license = "MIT OR Apache-2.0"
 name = "axum-server-dual-protocol"
 repository = "https://github.com/daxpedda/axum-server-dual-protocol"
-rust-version = "1.66"
-version = "0.7.0"
+rust-version = "1.82"
+version = "0.8.0"
 
 [features]
 default = ["rustls/aws-lc-rs"]
 
 [dependencies]
-axum-server = { version = "0.7.1", default-features = false, features = ["tls-rustls-no-provider"] }
+axum-server = { version = "0.8.0", default-features = false, features = ["tls-rustls-no-provider"] }
 bytes = { version = "1", default-features = false }
 http = "1"
 http-body-util = "0.1"
@@ -33,7 +33,7 @@ tower-service = "0.3"
 
 [dev-dependencies]
 anyhow = "1"
-axum = { version = "0.7", default-features = false }
+axum = { version = "0.8", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 hyper = "1"
 rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs"] }
@@ -115,6 +115,7 @@ format_push_string = "warn"
 get_unwrap = "warn"
 if_then_some_else_none = "warn"
 impl_trait_in_params = "warn"
+implicit_clone = "warn"
 indexing_slicing = "warn"
 infinite_loop = "warn"
 large_include_file = "warn"
@@ -145,7 +146,6 @@ str_to_string = "warn"
 string_add = "warn"
 string_lit_chars_any = "warn"
 string_slice = "warn"
-string_to_string = "warn"
 suspicious_xor_used_as_pow = "warn"
 todo = "warn"
 try_err = "warn"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ not with `RUSTFLAGS`.
 ## MSRV
 
 As this library heavily relies on [`axum-server`], [`axum`], [`tower`] and [`hyper`] the MSRV
-depends on theirs. At the point of time this was written the highest MSRV was [`axum`] with 1.66.
+depends on theirs. At the point of time this was written the highest MSRV was [`axum`] with 1.82.
 
 ## Changelog
 
@@ -94,20 +94,20 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
 additional terms or conditions.
 
-[CHANGELOG]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.7.0/CHANGELOG.md
-[LICENSE-MIT]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.7.0/LICENSE-MIT
-[LICENSE-APACHE]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.7.0/LICENSE-APACHE
+[CHANGELOG]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.8.0/CHANGELOG.md
+[LICENSE-MIT]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.8.0/LICENSE-MIT
+[LICENSE-APACHE]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.8.0/LICENSE-APACHE
 [`aws-lc-rs`]: https://docs.rs/aws-lc-rs/1
-[`axum`]: https://docs.rs/axum/0.7
-[`axum-server`]: https://docs.rs/axum-server/0.7.0
+[`axum`]: https://docs.rs/axum/0.8
+[`axum-server`]: https://docs.rs/axum-server/0.8.0
 [`bind_dual_protocol()`]:
-	https://docs.rs/axum-server-dual-protocol/0.7.0/axum_server_dual_protocol/fn.bind_dual_protocol.html
+	https://docs.rs/axum-server-dual-protocol/0.8.0/axum_server_dual_protocol/fn.bind_dual_protocol.html
 [`CryptoProvider`]: https://docs.rs/rustls/0.23/rustls/crypto/struct.CryptoProvider.html
 [`hyper`]: https://docs.rs/hyper/1
 [`Layer`]: https://docs.rs/tower-layer/0.3/tower_layer/trait.Layer.html
-[`Router`]: https://docs.rs/axum/0.7/axum/struct.Router.html
+[`Router`]: https://docs.rs/axum/0.8/axum/struct.Router.html
 [`ServerExt::set_upgrade()`]:
-	https://docs.rs/axum-server-dual-protocol/0.7.0/axum_server_dual_protocol/trait.ServerExt.html#tymethod.set_upgrade
+	https://docs.rs/axum-server-dual-protocol/0.8.0/axum_server_dual_protocol/trait.ServerExt.html#tymethod.set_upgrade
 [`tower`]: https://docs.rs/tower/0.4
 [`UpgradeHttpLayer`]:
-	https://docs.rs/axum-server-dual-protocol/0.7.0/axum_server_dual_protocol/struct.UpgradeHttpLayer.html
+	https://docs.rs/axum-server-dual-protocol/0.8.0/axum_server_dual_protocol/struct.UpgradeHttpLayer.html

--- a/clippy.toml
+++ b/clippy.toml
@@ -10,4 +10,5 @@ allowed-duplicate-crates = [
 	"windows_x86_64_gnu",
 	"windows_x86_64_gnullvm",
 	"windows_x86_64_msvc",
+	"windows_i686_gnullvm",
 ]

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -9,7 +9,7 @@
 //! any path added to the URI will redirect to the corresponding HTTPS URI.
 //! HTTPS requests should function as expected.
 
-#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stdout, reason = "Debug/example purposes")]
 
 use std::net::SocketAddr;
 

--- a/minimal-versions/Cargo.toml
+++ b/minimal-versions/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.0.0"
 [dependencies]
 axum-server-dual-protocol = { path = ".." }
 # `tower` v0.4.0 incorrectly only requires `tower-layer` v0.3.0
-tower-layer = "0.3.1"
+tower-layer = "0.3.3"

--- a/src/dual_protocol.rs
+++ b/src/dual_protocol.rs
@@ -31,22 +31,23 @@ use crate::UpgradeHttp;
 pub fn bind_dual_protocol(
 	address: SocketAddr,
 	config: RustlsConfig,
-) -> Server<DualProtocolAcceptor> {
+) -> Server<SocketAddr, DualProtocolAcceptor> {
 	let acceptor = DualProtocolAcceptor::new(config);
-
 	Server::bind(address).acceptor(acceptor)
 }
 
 /// Create a [`Server`] from an existing [`TcpListener`], accepting both
 /// HTTP and HTTPS on the same port.
-#[must_use]
+/// # Errors
+///
+/// Will return an `io::Error` if the `listener` cannot be created
 pub fn from_tcp_dual_protocol(
 	listener: TcpListener,
 	config: RustlsConfig,
-) -> Server<DualProtocolAcceptor> {
+) -> io::Result<Server<SocketAddr, DualProtocolAcceptor>> {
+	let server = axum_server::from_tcp(listener)?;
 	let acceptor = DualProtocolAcceptor::new(config);
-
-	Server::from_tcp(listener).acceptor(acceptor)
+	Ok(server.acceptor(acceptor))
 }
 
 /// Supplies configuration methods for [`Server`] with [`DualProtocolAcceptor`].
@@ -60,7 +61,7 @@ pub trait ServerExt {
 	fn set_upgrade(self, upgrade: bool) -> Self;
 }
 
-impl ServerExt for Server<DualProtocolAcceptor> {
+impl ServerExt for Server<SocketAddr, DualProtocolAcceptor> {
 	fn set_upgrade(mut self, upgrade: bool) -> Self {
 		self.get_mut().set_upgrade(upgrade);
 		self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //!
 //! As this library heavily relies on [`axum-server`](axum_server), [`axum`],
 //! [`tower`] and [`hyper`] the MSRV depends on theirs. At the point of time
-//! this was written the highest MSRV was [`axum`] with 1.66.
+//! this was written the highest MSRV was [`axum`] with 1.82.
 //!
 //! # Changelog
 //!
@@ -123,15 +123,15 @@
 //! license, shall be dual licensed as above, without any additional terms or
 //! conditions.
 //!
-//! [CHANGELOG]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.7.0/CHANGELOG.md
-//! [LICENSE-MIT]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.7.0/LICENSE-MIT
-//! [LICENSE-APACHE]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.7.0/LICENSE-APACHE
+//! [CHANGELOG]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.8.0/CHANGELOG.md
+//! [LICENSE-MIT]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.8.0/LICENSE-MIT
+//! [LICENSE-APACHE]: https://github.com/daxpedda/axum-server-dual-protocol/blob/v0.8.0/LICENSE-APACHE
 //! [`aws-lc-rs`]: https://docs.rs/aws-lc-rs/1
-//! [`axum`]: https://docs.rs/axum/0.7
+//! [`axum`]: https://docs.rs/axum/0.8
 //! [`CryptoProvider`]: tokio_rustls::rustls::crypto::CryptoProvider
 //! [`hyper`]: https://docs.rs/hyper/1
-//! [`Router`]: https://docs.rs/axum/0.7/axum/struct.Router.html
-//! [`tower`]: https://docs.rs/tower/0.4
+//! [`Router`]: https://docs.rs/axum/0.8/axum/struct.Router.html
+//! [`tower`]: https://docs.rs/tower/0.3
 
 mod dual_protocol;
 mod upgrade_http;

--- a/tests/dual_protocol.rs
+++ b/tests/dual_protocol.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs, reason = "Test should speak for itself")]
+
 mod util;
 
 use std::convert;
@@ -41,7 +43,9 @@ async fn from_tcp() -> Result<()> {
 		|address, config| {
 			// See <https://github.com/rust-lang/rust-clippy/issues/10011>.
 			let listener = TcpListener::bind(address).unwrap();
-			axum_server_dual_protocol::from_tcp_dual_protocol(listener, config)
+			//See github.com/tokio-rs/tokio/issues/7172 for details
+			listener.set_nonblocking(true).unwrap();
+			axum_server_dual_protocol::from_tcp_dual_protocol(listener, config).unwrap()
 		},
 		convert::identity,
 		Router::new().route("/", routing::get(|| async { "test" })),

--- a/tests/upgrade_http.rs
+++ b/tests/upgrade_http.rs
@@ -1,5 +1,9 @@
 #![cfg(test)]
-#![allow(clippy::missing_assert_message)]
+#![allow(
+	clippy::missing_assert_message,
+	reason = "No need message, we expect it to work"
+)]
+#![allow(missing_docs, reason = "Test should speak for itself")]
 
 mod util;
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -14,7 +14,10 @@ use hyper::body::{Body, Incoming};
 use reqwest::Certificate;
 use tower_service::Service;
 
-pub(crate) fn server(address: SocketAddr, config: RustlsConfig) -> Server<DualProtocolAcceptor> {
+pub(crate) fn server(
+	address: SocketAddr,
+	config: RustlsConfig,
+) -> Server<SocketAddr, DualProtocolAcceptor> {
 	axum_server_dual_protocol::bind_dual_protocol(address, config)
 }
 
@@ -38,9 +41,12 @@ where
 	<Router<RouterBody> as Service<Request<Incoming>>>::Future: Send,
 	ResponseBody: 'static + Body<Data = Bytes> + Send,
 	<ResponseBody as Body>::Error: StdError + Send + Sync,
-	ServerFn: 'static + FnOnce(SocketAddr, RustlsConfig) -> Server<DualProtocolAcceptor> + Send,
-	ServerLogicFn:
-		'static + FnOnce(Server<DualProtocolAcceptor>) -> Server<DualProtocolAcceptor> + Send,
+	ServerFn: 'static
+		+ FnOnce(SocketAddr, RustlsConfig) -> Server<SocketAddr, DualProtocolAcceptor>
+		+ Send,
+	ServerLogicFn: 'static
+		+ FnOnce(Server<SocketAddr, DualProtocolAcceptor>) -> Server<SocketAddr, DualProtocolAcceptor>
+		+ Send,
 	ClientFn: 'static + FnOnce(Certificate, SocketAddr) -> ClientFuture + Send,
 	ClientFuture: Future<Output = Result<()>> + Send,
 {


### PR DESCRIPTION
Hello,

The goal of this PR is to use [axum_server](https://github.com/programatik29/axum-server) v0.8 which was release 2 weeks ago.

@daxpedda Feel free to comments

Best regards,